### PR TITLE
Removed title escapes from templates

### DIFF
--- a/content/blog/2013/fifth-post.adoc
+++ b/content/blog/2013/fifth-post.adoc
@@ -1,0 +1,18 @@
+= Oliver's Post
+Oliver Fischer
+2013-11-11
+:jbake-type: post
+:jbake-status: published
+:jbake-tags: blog, asciidoc
+:idprefix:
+
+
+Oliver's first post and the fifth post at all.
+
+Nam id nisl quam. Donec a lorem sit amet libero pretium vulputate vel ut purus. Suspendisse leo arcu, 
+mattis et imperdiet luctus, pulvinar vitae mi. Quisque fermentum sollicitudin feugiat. Mauris nec leo 
+ligula. Vestibulum tristique odio ut risus ultricies a hendrerit quam iaculis. Duis tempor elit sit amet 
+ligula vehicula et iaculis sem placerat. Fusce dictum, metus at volutpat lacinia, elit massa auctor risus, 
+id auctor arcu enim eu augue. Donec ultrices turpis in mi imperdiet ac venenatis sapien sodales. In 
+consequat imperdiet nunc quis bibendum. Nulla semper, erat quis ornare tristique, lectus massa posuere 
+libero, ut vehicula lectus nunc ut lorem. Aliquam erat volutpat.

--- a/jbake.properties
+++ b/jbake.properties
@@ -1,3 +1,4 @@
 site.host=http://jbake.org
 render.tags=false
 render.sitemap=true
+render.archive=true

--- a/templates/archive.ftl
+++ b/templates/archive.ftl
@@ -19,7 +19,7 @@
 			<ul>
 		</#if>
 		
-		<li>${post.date?string("dd")} - <a href="${content.rootpath}${post.uri}"><#escape x as x?xml>${post.title}</#escape></a></li>
+		<li>${post.date?string("dd")} - <a href="${content.rootpath}${post.uri}">${post.title}</a></li>
 		<#assign last_month = post.date?string("MMMM yyyy")>
 		</#list>
 	</ul>

--- a/templates/header.ftl
+++ b/templates/header.ftl
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8"/>
-    <title><#if (content.title)??><#escape x as x?xml>${content.title}</#escape><#else>JBake</#if></title>
+    <title><#if (content.title)??>${content.title}<#else>JBake</#if></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
     <meta name="author" content="">

--- a/templates/index.ftl
+++ b/templates/index.ftl
@@ -7,7 +7,7 @@
 	</div>
 	<#list posts as post>
   		<#if (post.status == "published")>
-  			<a href="${post.uri}"><h1><#escape x as x?xml>${post.title}</#escape></h1></a>
+  			<a href="${post.uri}"><h1>${post.title}</h1></a>
   			<p>${post.date?string("dd MMMM yyyy")}</p>
   			<p>${post.body}</p>
   		</#if>

--- a/templates/menu.ftl
+++ b/templates/menu.ftl
@@ -27,6 +27,7 @@
                 <li><a href="#">One more separated link</a></li>
               </ul>
             </li>
+            <li><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>archive.html">Archive</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>

--- a/templates/page.ftl
+++ b/templates/page.ftl
@@ -4,7 +4,7 @@
 
 	<#if (content.title)??>
 	<div class="page-header">
-		<h1><#escape x as x?xml>${content.title}</#escape></h1>
+		<h1>${content.title}</h1>
 	</div>
 	<#else></#if>
 

--- a/templates/post.ftl
+++ b/templates/post.ftl
@@ -4,7 +4,7 @@
 
 	<#if (content.title)??>
 	<div class="page-header">
-		<h1><#escape x as x?xml>${content.title}</#escape></h1>
+		<h1>${content.title}</h1>
 	</div>
 	<#else></#if>
 


### PR DESCRIPTION
This PR provides a fix for issue jbake-org/jbake-example-project-freemarker#12 and removes the escape directives from various templates as it has been already done for jBake itself.

See jbake-org/jbake#582 for further information.